### PR TITLE
[Doc] fix docs index links

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -171,8 +171,8 @@ title: "Index"
 * [`<TextField>`](./TextField.md)
 * [`<TextInput>`](./TextInput.md)
 * [`<TimeInput>`](./TimeInput.md)
-* [<`Title>`](./Title.md)
-* [<`TitlePortal>`](./AppBar.md#children)
+* [`<Title>`](./Title.md)
+* [`<TitlePortal>`](./AppBar.md#children)
 * [`<ToggleThemeButton>`](./ToggleThemeButton.md)
 * [`<TourProvider>`](https://marmelab.com/ra-enterprise/modules/ra-tour)<img class="icon" src="./img/premium.svg" />
 * [`<TranslatableFields>`](./TranslatableFields.md)


### PR DESCRIPTION
Little fix from https://github.com/marmelab/react-admin/pull/8681#discussion_r1147860491

![image](https://user-images.githubusercontent.com/15650777/227617630-4933c244-8150-41e5-b251-34e283a3eb56.png)
